### PR TITLE
Cleaned up API a bit and added support for acceptNotification

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Quickpay;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\Quickpay\Message\Notification;
 
 /**
  * Quickpay Gateway
@@ -20,9 +21,7 @@ class Gateway extends AbstractGateway
 		return array(
 			'merchant' => '',
 			'agreement' => '',
-			'payment_window_agreement' => '',
 			'apikey' => '',
-			'payment_window_apikey' => '',
 			'privatekey' => '',
 			'language' => '',
 			'payment_methods' => array()
@@ -47,16 +46,6 @@ class Gateway extends AbstractGateway
 		return $this->setParameter('merchant', $value);
 	}
 
-	public function getPaymentWindowAgreement()
-	{
-		return $this->getParameter('payment_window_agreement');
-	}
-
-	public function setPaymentWindowAgreement($value)
-	{
-		return $this->setParameter('payment_window_agreement', $value);
-	}
-
 	public function getAgreement()
 	{
 		return $this->getParameter('agreement');
@@ -65,16 +54,6 @@ class Gateway extends AbstractGateway
 	public function setAgreement($value)
 	{
 		return $this->setParameter('agreement', $value);
-	}
-
-	public function setPaymentWindowApikey($value)
-	{
-		return $this->setParameter('payment_window_apikey', $value);
-	}
-
-	public function getPaymentWindowApikey()
-	{
-		return $this->getParameter('payment_window_apikey');
 	}
 
 	public function setApikey($value)
@@ -233,4 +212,8 @@ class Gateway extends AbstractGateway
 		return $this->completeRequest($parameters);
 	}
 
+	public function acceptNotification()
+	{
+		return new Notification($this->httpRequest, $this->getPrivatekey());
+	}
 }

--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -10,9 +10,7 @@ class CompletePurchaseResponse extends Response
 		if($this->getResponseBody()){
 			$response_body = json_decode($this->getResponseBody());
 			$data = end($response_body->operations);
-			if ($response_body->accepted && $data->type=='authorize' && $data->qp_status_code=="20000" && $response_body->test_mode != true) {
-				return true;
-			}
+			return ($response_body->accepted && $data->type=='authorize' && $data->qp_status_code=="20000");
 		}
 
 		// always returns false on returnURL, because Quickpay returnURL get no data

--- a/src/Message/Notification.php
+++ b/src/Message/Notification.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Omnipay\Quickpay\Message;
+
+
+use Omnipay\Common\Exception\InvalidResponseException;
+use Omnipay\Common\Message\NotificationInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class Notification implements NotificationInterface
+{
+
+    /**
+     * The HTTP request object.
+     *
+     * @var \Symfony\Component\HttpFoundation\Request
+     */
+    protected $httpRequest;
+
+    protected $privateKey;
+
+    protected $data;
+
+    public function setPrivateKey($value)
+    {
+        $this->privateKey = $value;
+        return $this;
+    }
+
+    public function getPrivateKey()
+    {
+        return $this->privateKey;
+    }
+
+    public function __construct(Request $request, $privateKey = null)
+    {
+        $this->httpRequest = $request;
+        $this->privateKey = $privateKey;
+    }
+
+    public function getData()
+    {
+        if($this->data){
+            return $this->data;
+        }
+
+        if ($this->httpRequest->headers->get('Content-Type') == "application/json") {
+            $data = json_decode($this->httpRequest->getContent());
+
+            $header_checksum = $this->httpRequest->headers->get('Quickpay-Checksum-Sha256');
+            // validate with accounts private key.
+            $our_checksum = hash_hmac("sha256", $this->httpRequest->getContent(), $this->getPrivateKey());
+            if ($our_checksum != $header_checksum) {
+                throw new InvalidResponseException;
+            }
+
+            $this->data = $data;
+        }
+
+        return $this->data;
+    }
+
+    /**
+     * Gateway Reference
+     *
+     * @return string A reference provided by the gateway to represent this transaction
+     */
+    public function getTransactionReference()
+    {
+        if ($data = $this->getData()) {
+            return $data->id;
+        }
+    }
+
+    /**
+     * Was the transaction successful?
+     *
+     * @return string Transaction status, one of {@see STATUS_COMPLETED}, {@see #STATUS_PENDING},
+     * or {@see #STATUS_FAILED}.
+     */
+    public function getTransactionStatus()
+    {
+        if($data = $this->getData()){
+            $op = end($data->operations);
+            if($op->pending == false && $op->qp_status_code == "20000"){
+                return NotificationInterface::STATUS_COMPLETED;
+            } else if($op->pending){
+                return NotificationInterface::STATUS_PENDING;
+            }
+        }
+
+        return NotificationInterface::STATUS_FAILED;
+    }
+
+    /**
+     * Response Message
+     *
+     * @return string A response message from the payment gateway
+     */
+    public function getMessage()
+    {
+        if($data = $this->getData()){
+            $op = end($data->operations);
+            return $op->qp_status_msg;
+        }
+        return '';
+    }
+}

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -22,7 +22,7 @@ class PurchaseRequest extends AbstractRequest
 		$params = array(
 			"version"      => "v10",
 			"merchant_id"  => $this->getMerchant(),
-			"agreement_id" => $this->getPaymentWindowAgreement(),
+			"agreement_id" => $this->getAgreement(),
 			"order_id"     => "orderID" . $this->getTransactionId(),
 			"amount"       => $this->getAmountInteger(),
 			"currency"     => $this->getCurrency(),
@@ -54,7 +54,7 @@ class PurchaseRequest extends AbstractRequest
 	 */
 	public function createChecksum($data)
 	{
-		$data["checksum"] = $this->sign($data, $this->getPaymentWindowApikey());
+		$data["checksum"] = $this->sign($data, $this->getApikey());
 		return $data;
 	}
 


### PR DESCRIPTION
Removed payment_window parameters. Only an agreement and apikey should be used.
Added notification class that deals with incoming notifications, see: https://github.com/thephpleague/omnipay#incoming-notifications
Ensure that AbstractRequest actually returns a proper omnipay response (not an HTTP response)
