### PR TITLE
Correct class name

### DIFF
--- a/src/Message/CaptureResponse.php
+++ b/src/Message/CaptureResponse.php
@@ -2,7 +2,7 @@
 
 namespace Omnipay\Quickpay\Message;
 
-class NotifyResponse extends Response
+class CaptureResponse extends Response
 {
 	// return the response body for the app to use
 	public function isSuccessful()


### PR DESCRIPTION
I noticed the classname in the CaptureResponse file was set to NotifyResponse. This pr fixes that.